### PR TITLE
Installer Url

### DIFF
--- a/carl-repo.json
+++ b/carl-repo.json
@@ -9,11 +9,11 @@
 			"files": [
 				{
 					"path": "init.lua",
-					"url": "https://raw.githubusercontent.com/ghostdevv/cc-carl/main/packages/client/init.lua"
+					"url": "packages/client/init.lua"
 				},
 				{
 					"path": "cli.lua",
-					"url": "https://raw.githubusercontent.com/ghostdevv/cc-carl/main/packages/client/carl.lua"
+					"url": "packages/client/carl.lua"
 				}
 			]
 		}

--- a/carl-repo.json
+++ b/carl-repo.json
@@ -13,7 +13,7 @@
 				},
 				{
 					"path": "cli.lua",
-					"url": "packages/client/carl.lua"
+					"url": "packages/client/cli.lua"
 				}
 			]
 		}

--- a/packages/client/init.lua
+++ b/packages/client/init.lua
@@ -373,7 +373,7 @@ end
 --- @param url string
 --- @return string?
 function api.addRepository(url)
-    local repository = apiRequest("/repo?repository=" .. url)
+    local repository = apiRequest("/repo/metadata?url=" .. url)
     if repository == nil then return nil end
 
     repositories:set(repository["name"], url)

--- a/packages/client/init.lua
+++ b/packages/client/init.lua
@@ -345,7 +345,7 @@ function api.install(repository, package)
     log("info", "PKG", "Resolving \"%s\"", identifier)
 
     local repo_url = repositories:get(repository)
-    local pkg_data = apiRequest("/pkg/" .. identifier, { definitionURL = repo_url })
+    local pkg_data = apiRequest("/pkg/" .. package, { repository = repo_url })
     if pkg_data == nil then return nil end
 
     log("success", "PKG", "Found v%s with %d file%s",
@@ -373,9 +373,9 @@ end
 --- @param url string
 --- @return string?
 function api.addRepository(url)
-    local repository = apiRequest("/repo?definitionURL=" .. url)
-
+    local repository = apiRequest("/repo?repository=" .. url)
     if repository == nil then return nil end
+
     repositories:set(repository["name"], url)
     return repository["name"]
 end

--- a/packages/client/installer.lua
+++ b/packages/client/installer.lua
@@ -87,6 +87,8 @@ elseif repository:sub(1, 4) ~= "http" then
     repository = DEFAULT_REPO:format(repository)
 end
 
+DEFAULT_REPOSITORIES["carl"] = repository
+
 local pkg = getCarlPkg(repository)
 
 if pkg == nil then

--- a/packages/client/installer.lua
+++ b/packages/client/installer.lua
@@ -1,7 +1,6 @@
-local DEFAULT_REPOSITORIES = {
-    glib = "https://raw.githubusercontent.com/ghostdevv/cc-glib/main/carl-repo.json",
-    carl = "https://raw.githubusercontent.com/ghostdevv/cc-carl/main/carl-repo.json",
-}
+local PKG_URL = "https://carl.willow.sh/pkg/carl?repository="
+local DEFAULT_REPO = "https://raw.githubusercontent.com/ghostdevv/cc-carl/%s/carl-repo.json"
+local DEFAULT_REPOSITORIES = { glib = "https://raw.githubusercontent.com/ghostdevv/cc-glib/main/carl-repo.json" }
 
 -- * Functions
 
@@ -32,8 +31,8 @@ end
 
 --- Get Carl's manifest
 --- @return table?
-local function getCarlPkg()
-    local response = http.get("https://carl.willow.sh/pkg/carl/carl")
+local function getCarlPkg(repository)
+    local response = http.get(PKG_URL .. repository)
 
     if response == nil then
         message("error", "API Error", "Unable to connect to API")
@@ -76,12 +75,19 @@ local MANIFEST_FILE = join(CARL_DIR, "/manifest")
 
 -- * Script
 
-if fs.exists(".carl") then
+if fs.exists(CARL_DIR) then
     print("It looks like carl is already installed!")
     return
 end
 
-local pkg = getCarlPkg()
+local repository = arg[3]
+if repository == nil then
+    repository = DEFAULT_REPO:format("main")
+elseif repository:sub(1, 4) ~= "http" then
+    repository = DEFAULT_REPO:format(repository)
+end
+
+local pkg = getCarlPkg(repository)
 
 if pkg == nil then
     return
@@ -135,9 +141,9 @@ fs.makeDir(CARL_DIR)
 fs.makeDir(PACKAGES_DIR)
 
 -- ? Repositories file
-local manifest_file = fs.open(MANIFEST_FILE, "w")
-manifest_file.write(textutils.serialise(DEFAULT_REPOSITORIES, { compact = true, allow_repetitions = false }))
-manifest_file.close()
+local repositories_file = fs.open(REPOSITORIES_FILE, "w")
+repositories_file.write(textutils.serialise(DEFAULT_REPOSITORIES, { compact = true, allow_repetitions = false }))
+repositories_file.close()
 
 -- ? Manifest file
 local manifest_file = fs.open(MANIFEST_FILE, "w")

--- a/packages/client/installer.lua
+++ b/packages/client/installer.lua
@@ -1,3 +1,8 @@
+local DEFAULT_REPOSITORIES = {
+    glib = "https://raw.githubusercontent.com/ghostdevv/cc-glib/main/carl-repo.json",
+    carl = "https://raw.githubusercontent.com/ghostdevv/cc-carl/main/carl-repo.json",
+}
+
 -- * Functions
 
 --- Join path segments together
@@ -131,7 +136,7 @@ fs.makeDir(PACKAGES_DIR)
 
 -- ? Repositories file
 local manifest_file = fs.open(MANIFEST_FILE, "w")
-manifest_file.write("{}")
+manifest_file.write(textutils.serialise(DEFAULT_REPOSITORIES, { compact = true, allow_repetitions = false }))
 manifest_file.close()
 
 -- ? Manifest file

--- a/packages/schema/json-schema/package.json
+++ b/packages/schema/json-schema/package.json
@@ -27,7 +27,6 @@
         "properties": {
           "url": {
             "type": "string",
-            "format": "uri",
             "description": "The url this file can be downloaded from."
           },
           "path": {

--- a/packages/schema/json-schema/repository.json
+++ b/packages/schema/json-schema/repository.json
@@ -39,7 +39,6 @@
               "properties": {
                 "url": {
                   "type": "string",
-                  "format": "uri",
                   "description": "The url this file can be downloaded from."
                 },
                 "path": {

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -25,10 +25,7 @@ export const packageSchema = z.object({
 	files: z
 		.array(
 			z.object({
-				url: z
-					.string()
-					.url()
-					.describe('The url this file can be downloaded from.'),
+				url: z.string().describe('The url this file can be downloaded from.'),
 				path: z
 					.string()
 					.describe('The relative path this file will be saved to.'),

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,5 +1,5 @@
-import { getRepository, resolveRepositoryHost } from './repositories';
-import { error, fail } from './utils';
+import { getRepository } from './repositories';
+import { error, fail, isURL } from './utils';
 import { logger } from 'hono/logger';
 import type { Env } from './types';
 import { cors } from 'hono/cors';
@@ -35,16 +35,14 @@ server.get('/file', async (c) => {
 });
 
 //? Get package information
-server.get('/pkg/:repository/:package', async (c) => {
+server.get('/pkg/:package', async (c) => {
 	const workerURL = new URL(c.req.url);
 
-	const host = resolveRepositoryHost(
-		c.req.param('repository'),
-		c.req.query('definitionURL'),
-	);
+	const repository_url = c.req.query('repository');
+	if (!isURL(repository_url)) throw fail('Repository URL is invalid');
 
 	const repository = await getRepository(
-		host,
+		repository_url,
 		c.env.REPOSITORY_CACHE,
 		`${workerURL.origin}/file`,
 	);
@@ -61,16 +59,14 @@ server.get('/pkg/:repository/:package', async (c) => {
 	});
 });
 
-server.get('/repo/:repository?', async (c) => {
+server.get('/repo', async (c) => {
 	const workerURL = new URL(c.req.url);
 
-	const host = resolveRepositoryHost(
-		c.req.param('repository'),
-		c.req.query('definitionURL'),
-	);
+	const repository_url = c.req.query('repository');
+	if (!isURL(repository_url)) throw fail('Repository URL is invalid');
 
 	const repository = await getRepository(
-		host,
+		repository_url,
 		c.env.REPOSITORY_CACHE,
 		`${workerURL.origin}/file`,
 	);

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -38,11 +38,8 @@ server.get('/file', async (c) => {
 server.get('/pkg/:package', async (c) => {
 	const workerURL = new URL(c.req.url);
 
-	const repository_url = c.req.query('repository');
-	if (!isURL(repository_url)) throw fail('Repository URL is invalid');
-
 	const repository = await getRepository(
-		repository_url,
+		c.req.query('repository')!,
 		c.env.REPOSITORY_CACHE,
 		`${workerURL.origin}/file`,
 	);
@@ -59,19 +56,19 @@ server.get('/pkg/:package', async (c) => {
 	});
 });
 
-server.get('/repo', async (c) => {
+server.get('/repo/metadata', async (c) => {
 	const workerURL = new URL(c.req.url);
 
-	const repository_url = c.req.query('repository');
-	if (!isURL(repository_url)) throw fail('Repository URL is invalid');
-
-	const repository = await getRepository(
-		repository_url,
+	const metadata: Object = await getRepository(
+		c.req.query('url')!,
 		c.env.REPOSITORY_CACHE,
 		`${workerURL.origin}/file`,
 	);
 
-	return c.json(repository);
+	// @ts-ignore
+	delete metadata['packages'];
+
+	return c.json(metadata);
 });
 
 export default server;

--- a/packages/worker/src/repositories.ts
+++ b/packages/worker/src/repositories.ts
@@ -9,13 +9,13 @@ interface RepositoryCacheValue {
 }
 
 export async function getRepository(
-	repository_url: string,
+	repositoryUrl: string,
 	cache: Env['Bindings']['REPOSITORY_CACHE'],
 	downloadProxyURL: string,
 ): Promise<Repository> {
-	if (!isURL(repository_url)) throw fail('Repository URL is invalid');
+	if (!isURL(repositoryUrl)) throw fail('Repository URL is invalid');
 
-	const cacheValue = await cache.get(repository_url);
+	const cacheValue = await cache.get(repositoryUrl);
 
 	if (cacheValue) {
 		const { expires, repository } = JSON.parse(cacheValue) as RepositoryCacheValue;
@@ -23,7 +23,7 @@ export async function getRepository(
 		if (expires > Date.now()) return repository;
 	}
 
-	const rawDefinition = await ofetch(repository_url, {
+	const rawDefinition = await ofetch(repositoryUrl, {
 		responseType: 'json',
 		headers: {
 			Accept: 'application/json',
@@ -39,7 +39,7 @@ export async function getRepository(
 			...pkg,
 			files: pkg.files.map((file) => ({
 				url: `${downloadProxyURL}?url=${encodeURIComponent(
-					new URL(file.url, repository_url).href, // allow relative URLs
+					new URL(file.url, repositoryUrl).href, // allow relative URLs
 				)}`,
 				path: file.path,
 			})),
@@ -53,7 +53,7 @@ export async function getRepository(
 	}
 
 	await cache.put(
-		repository_url,
+		repositoryUrl,
 		JSON.stringify({
 			repository: definition,
 			expires: Date.now() + 300000, // five minutes,

--- a/packages/worker/src/repositories.ts
+++ b/packages/worker/src/repositories.ts
@@ -26,6 +26,8 @@ export async function getRepository(
 		headers: {
 			Accept: 'application/json',
 		},
+	}).catch(() => {
+		throw fail(`Failed to fetch repository definition`);
 	});
 
 	const definition = await repositorySchema.parseAsync(rawDefinition);

--- a/packages/worker/src/repositories.ts
+++ b/packages/worker/src/repositories.ts
@@ -3,73 +3,25 @@ import { ofetch } from 'ofetch';
 import { fail } from './utils';
 import { Env } from './types';
 
-export const defaultRepositories = Object.freeze({
-	glib: 'https://raw.githubusercontent.com/ghostdevv/cc-glib/main/carl-repo.json',
-	carl: 'https://raw.githubusercontent.com/ghostdevv/cc-carl/main/carl-repo.json',
-});
-
-function isDefaultRepository(name: any): name is keyof typeof defaultRepositories {
-	// @ts-ignore bad
-	return typeof name == 'string' && defaultRepositories[name];
-}
-
-function isURL(url: any): url is string | URL {
-	try {
-		new URL(url);
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-interface RepositoryHost {
-	name?: string;
-	url: string;
-}
-
-export function resolveRepositoryHost(
-	name?: keyof typeof defaultRepositories | (string & {}),
-	customURL?: string,
-): RepositoryHost {
-	if (isDefaultRepository(name)) {
-		return {
-			name,
-			url: defaultRepositories[name],
-		};
-	}
-
-	if (!isURL(customURL)) {
-		throw fail('Custom repository URL is invalid');
-	}
-
-	return { name, url: customURL };
-}
-
 interface RepositoryCacheValue {
 	repository: Repository;
 	expires: number;
 }
 
 export async function getRepository(
-	host: RepositoryHost,
+	repository: string,
 	cache: Env['Bindings']['REPOSITORY_CACHE'],
 	downloadProxyURL: string,
 ): Promise<Repository> {
-	const cacheValue = await cache.get(host.url);
+	const cacheValue = await cache.get(repository);
 
 	if (cacheValue) {
 		const { expires, repository } = JSON.parse(cacheValue) as RepositoryCacheValue;
 
-		if (expires > Date.now()) {
-			if (host.name && repository.name != host.name) {
-				throw fail('Repository name mismatch');
-			}
-
-			return repository;
-		}
+		if (expires > Date.now()) return repository;
 	}
 
-	const rawDefinition = await ofetch(host.url, {
+	const rawDefinition = await ofetch(repository, {
 		responseType: 'json',
 		headers: {
 			Accept: 'application/json',
@@ -77,10 +29,6 @@ export async function getRepository(
 	});
 
 	const definition = await repositorySchema.parseAsync(rawDefinition);
-
-	if (host.name && definition.name != host.name) {
-		throw fail('Repository name mismatch');
-	}
 
 	definition.packages = definition.packages.map((pkg) => {
 		return {
@@ -99,7 +47,7 @@ export async function getRepository(
 	}
 
 	await cache.put(
-		host.url,
+		repository,
 		JSON.stringify({
 			repository: definition,
 			expires: Date.now() + 300000, // five minutes,

--- a/packages/worker/src/repositories.ts
+++ b/packages/worker/src/repositories.ts
@@ -1,6 +1,6 @@
 import { Repository, repositorySchema } from '@carl/schema';
 import { ofetch } from 'ofetch';
-import { fail } from './utils';
+import { fail, isURL } from './utils';
 import { Env } from './types';
 
 interface RepositoryCacheValue {
@@ -13,6 +13,8 @@ export async function getRepository(
 	cache: Env['Bindings']['REPOSITORY_CACHE'],
 	downloadProxyURL: string,
 ): Promise<Repository> {
+	if (!isURL(repository_url)) throw fail('Repository URL is invalid');
+
 	const cacheValue = await cache.get(repository_url);
 
 	if (cacheValue) {

--- a/packages/worker/src/utils.ts
+++ b/packages/worker/src/utils.ts
@@ -22,3 +22,12 @@ export function fail(message: string) {
 		res: Response.json({ success: false, message }, { status: 200 }),
 	});
 }
+
+export function isURL(url: any): url is string | URL {
+	try {
+		new URL(url);
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
I have implemented #8 and #10. When running the install script, an optional branch or url can be specified. For example `wget run https://carl.willow.sh/install installer-url`.

# Changes

- The install script now allows for a branch name or url to be specified to install carl from.
- The default repositories system on the worker has been removed.
- Default repositories are now added on install, defined in [`installer.lua`](https://github.com/ghostdevv/cc-carl/blob/20f3761dee93722afe48fa52d5d02b1abc949293/packages/client/installer.lua#L3).
- Changed endpoints to not take repository name as a parameter as that information is now superfluous.
- Query parameter `definitionUrl` changed to `repository`.
- Relative URLs are now allowed in repository definitions.
- The [endpoint used when fetching a repository name](https://github.com/ghostdevv/cc-carl/blob/20f3761dee93722afe48fa52d5d02b1abc949293/packages/worker/src/index.ts#L59) now doesn't return packages as this could theoretically be very long and is unnecessary here.

# Queries

As commented in #10, I don't know if there should be a command to update your repositories with the current defaults from carl.

As mentioned, I changed the query parameter to `repository`. Should this be simplified further to simply be `repo`? Also for repository metadata, I'm using the query parameter `url` as it seems superfluous to use repository again, however this may be better for consistency.

Let me know what you think!